### PR TITLE
feat: connect CLI to Personal Data Server 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.0.2 (2025-02-13)
+
+
+### Features
+
+* add auth ([efb4e0d](https://github.com/kaf-lamed-beyt/bsky-backups-cli/commit/efb4e0d2ea30d96b64fb2f7a7dec9579914a5b38))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky-backups-cli",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky-backups-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -1,0 +1,64 @@
+import chalk from "chalk";
+import Agent, { CredentialSession } from "@atproto/api";
+import { Config, readConfig, writeConfig } from "../utils/config";
+import keytar from "keytar";
+
+const SERVICE_NAME = "bsky-backup-cli";
+
+export class Session {
+  private agent: Agent;
+  private config: Config;
+
+  constructor(pdsUrl?: string) {
+    this.config = readConfig();
+    const serviceUrl = pdsUrl || this.config.pdsUrl || "https://bsky.app";
+    const session = new CredentialSession(new URL(serviceUrl));
+    this.agent = new Agent(session);
+    this.resumeSession();
+  }
+
+  private resumeSession() {
+    if (this.config.bluesky?.accessJwt && this.config.bluesky.did) {
+      this.agent
+        .resumeSession({
+          did: this.config.bluesky.did,
+          handle: String(this.config.bluesky.handle),
+          accessJwt: String(this.config.bluesky.accessJwt),
+          refreshJwt: String(this.config.bluesky.refreshJwt),
+          active: Boolean(this.config.bluesky.active),
+        })
+        .catch((error) => {
+          console.log(`${chalk.yellow(`\nError resuming session:`, error)}`);
+        });
+    }
+  }
+
+  async saveSession(session: {
+    did: string;
+    handle: string;
+    accessJwt: string;
+    refreshJwt: string;
+  }) {
+    await keytar.setPassword(SERVICE_NAME, session.did, session.refreshJwt);
+
+    writeConfig({
+      ...this.config,
+      pdsUrl: this.agent.serviceUrl.toString(),
+      bluesky: { ...session },
+    });
+  }
+
+  async clearSession(did: string) {
+    await keytar.deletePassword(SERVICE_NAME, did);
+    writeConfig({
+      ...this.config,
+      bluesky: undefined,
+      accounts: this.config.accounts.filter((d: string) => d !== did),
+    });
+    console.log(`Logged out of ${did}`);
+  }
+
+  getAgent() {
+    return this.agent;
+  }
+}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -7,14 +7,14 @@ export const authCommands = (program: Command) => {
   program
     .name("bsky-backup")
     .description(chalk.cyan("✨ CLI tool for backing up Bluesky posts ✨"))
-    .version("1.0.0");
 
   program
     .command("login")
     .description("Authenticate with Bluesky")
-    .action(async () => {
+    .option("--pds <url>", "Custom PDS URL", "https://bksy.social")
+    .action(async (options) => {
       try {
-        const auth = new BlueskyAuth();
+        const auth = new BlueskyAuth(options.pds);
         const session = await auth.login();
         if (session) {
           console.log(
@@ -39,8 +39,11 @@ export const authCommands = (program: Command) => {
   program.addHelpText(
     "afterAll",
     `\n${chalk.yellow.bold("Examples:")}
-    ${chalk.cyan("$ bsky-backup login")}      → Authenticate with Bluesky
-    ${chalk.cyan("$ bsky-backup logout")}     → Remove stored credentials
+    ${chalk.cyan("$ bsky-backup login")}          → Authenticate with Bluesky
+    ${chalk.cyan("$ bsky-backup logout")}         → Remove stored credentials
+    ${chalk.cyan("$ bsky test create-account")}   → If you want to create an account on your PDS
+    ${chalk.cyan("$ bsky test create-post")}      → Create a test post or multiple test posts on your PDS. You also have the option to replying to a post
+    ${chalk.cyan("$ bsky test list-post")}        → List test posts on your PDS
 
     ${chalk.green("For more details, use:")}
     ${chalk.cyan("$ bsky-backup --help")}`,

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 import chalk from "chalk";
 import { BlueskyAuth } from "../auth/bsky";
-import { Command } from "commander";
 
-export const authCommands = (program: Command) => {
+export const authCommands = (program) => {
   program
     .name("bsky-backup")
     .description(chalk.cyan("✨ CLI tool for backing up Bluesky posts ✨"))
@@ -11,20 +10,13 @@ export const authCommands = (program: Command) => {
   program
     .command("login")
     .description("Authenticate with Bluesky")
-    .option("--pds <url>", "Custom PDS URL", "https://bksy.social")
+    .option("--pds <url>", "Custom PDS URL", "https://bksy.app")
     .action(async (options) => {
       try {
         const auth = new BlueskyAuth(options.pds);
-        const session = await auth.login();
-        if (session) {
-          console.log(
-            `Successfully logged in as ${chalk.bgBlueBright(session.handle)}`,
-          );
-        } else {
-          console.log(chalk.red("Login failed. No session returned."));
-        }
+        await auth.login();
       } catch (error) {
-        console.log((error as Error).message);
+        console.log((error.message));
       }
     });
 
@@ -39,11 +31,11 @@ export const authCommands = (program: Command) => {
   program.addHelpText(
     "afterAll",
     `\n${chalk.yellow.bold("Examples:")}
-    ${chalk.cyan("$ bsky-backup login")}          → Authenticate with Bluesky
-    ${chalk.cyan("$ bsky-backup logout")}         → Remove stored credentials
-    ${chalk.cyan("$ bsky test create-account")}   → If you want to create an account on your PDS
-    ${chalk.cyan("$ bsky test create-post")}      → Create a test post or multiple test posts on your PDS. You also have the option to replying to a post
-    ${chalk.cyan("$ bsky test list-post")}        → List test posts on your PDS
+    ${chalk.cyan("$ bsky-backup login")}                 → Authenticate with Bluesky
+    ${chalk.cyan("$ bsky-backup logout")}                → Remove stored credentials
+    ${chalk.cyan("$ bsky test create-account")}          → If you want to create an account on your PDS
+    ${chalk.cyan("$ bsky-backup test create-post")}      → Create a test post or multiple test posts on your PDS. You also have the option to replying to a post
+    ${chalk.cyan("$ bsky-backup test list-post")}        → List test posts on your PDS
 
     ${chalk.green("For more details, use:")}
     ${chalk.cyan("$ bsky-backup --help")}`,

--- a/src/cli/pds-actions.ts
+++ b/src/cli/pds-actions.ts
@@ -1,0 +1,229 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import ora from "ora";
+import inquirer from "inquirer";
+import { PdsAccountManager } from "../pds/account";
+import { Record } from "@atproto/api/dist/client/types/app/bsky/graph/starterpack";
+
+export const pdsActions = (program: Command) => {
+  const test = program
+    .command("test")
+    .description("Test utilities for the Bluesky-Storacha backup CLI");
+
+  test
+    .command("create-account")
+    .description("Create a test account on a development PDS")
+    .action(async () => {
+      try {
+        const answers = await inquirer.prompt([
+          {
+            type: "input",
+            name: "pds",
+            message: "Enter development PDS URL:",
+            validate: (input) =>
+              input.startsWith("https://") ||
+              "PDS URL must start with https://",
+          },
+          {
+            type: "input",
+            name: "handle",
+            message: "Enter test account handle:",
+            validate: (input) =>
+              input.includes(".") ||
+              "Handle must include a domain (e.g., user.domain.com)",
+          },
+          {
+            type: "input",
+            name: "email",
+            message: "Enter test email address:",
+            validate: (input) =>
+              input.includes("@") || "Please enter a valid email address",
+          },
+          {
+            type: "password",
+            name: "password",
+            message: "Enter test account password:",
+            validate: (input) =>
+              input.length >= 8 || "Password must be at least 8 characters",
+          },
+          {
+            type: "input",
+            name: "inviteCode",
+            message: "Enter PDS invite code (contact your PDS administrator):",
+            validate: (input) => input.length > 0 || "Invite code is required",
+          },
+        ]);
+
+        const spinner = ora("Creating test account...").start();
+        const manager = new PdsAccountManager(answers.pds);
+        const account = await manager.createAccountOnPds({
+          email: answers.email,
+          handle: answers.handle,
+          password: answers.password,
+          inviteCode: answers.inviteCode,
+        });
+        spinner.succeed(`Created test account: ${account.handle}`);
+
+        console.log(chalk.green("\nTest account created successfully!"));
+        await showTestMenu(answers.pds);
+      } catch (error) {
+        console.error(chalk.red(`\nError: ${(error as Error).message}`));
+
+        if ((error as Error).message.includes("invite")) {
+          console.log(chalk.yellow("\nAbout invite codes:"));
+          console.log(
+            "1. Invite codes are required by PDS instances to control account creation",
+          );
+          console.log(
+            "2. Contact your PDS administrator to obtain a valid invite code",
+          );
+        }
+        process.exit(1);
+      }
+    });
+
+  test
+    .command("create-post")
+    .description("Create test posts on your development PDS")
+    .action(async () => {
+      try {
+        const { pds } = await inquirer.prompt([
+          {
+            type: "input",
+            name: "pds",
+            message: "Enter development PDS URL:",
+            validate: (input) =>
+              input.startsWith("https://") ||
+              "PDS URL must start with https://",
+          },
+        ]);
+
+        const { postType } = await inquirer.prompt([
+          {
+            type: "list",
+            name: "postType",
+            message: "What type of test posts would you like to generate?",
+            choices: [
+              { name: "Single test post", value: "single" },
+              { name: "Test reply to another post", value: "reply" },
+            ],
+          },
+        ]);
+
+        const manager = new PdsAccountManager(pds);
+
+        if (postType === "single") {
+          const { text } = await inquirer.prompt([
+            {
+              type: "input",
+              name: "text",
+              message: "Enter test post content:",
+              validate: (input) =>
+                input.length > 0 || "Post content cannot be empty",
+            },
+          ]);
+
+          const spinner = ora("Creating test post...").start();
+          const post = await manager.createPostOnPds(text);
+          spinner.succeed("Test post created successfully!");
+          console.log(chalk.green("\nPost details:"));
+          console.log(chalk.white(`  URI: ${post.uri}`));
+          console.log(chalk.white(`  Text: ${text}`));
+        } else if (postType === "reply") {
+          const { uri, text } = await inquirer.prompt([
+            {
+              type: "input",
+              name: "uri",
+              message: "Enter the URI of the post to reply to:",
+              validate: (input) =>
+                input.startsWith("at://") || "URI must start with at://",
+            },
+            {
+              type: "input",
+              name: "text",
+              message: "Enter test reply content:",
+              validate: (input) => input.length > 0 || "Reply cannot be empty",
+            },
+          ]);
+
+          const spinner = ora("Creating test reply...").start();
+          const post = await manager.createPostOnPds(text, uri);
+          spinner.succeed("Test reply created successfully!");
+          console.log(chalk.green("\nReply details:"));
+          console.log(chalk.white(`  URI: ${post.uri}`));
+          console.log(chalk.white(`  Text: ${text}`));
+        }
+      } catch (error) {
+        console.error(chalk.red(`Error: ${(error as Error).message}`));
+      }
+    });
+
+  test
+    .command("list-posts")
+    .description("List test posts from your development account")
+    .action(async () => {
+      try {
+        const { pds, limit } = await inquirer.prompt([
+          {
+            type: "input",
+            name: "pds",
+            message: "Enter development PDS URL:",
+            validate: (input) =>
+              input.startsWith("https://") ||
+              "PDS URL must start with https://",
+          },
+          {
+            type: "number",
+            name: "limit",
+            message: "How many posts to retrieve?",
+            default: 10,
+          },
+        ]);
+
+        const spinner = ora("Fetching test posts...").start();
+        const manager = new PdsAccountManager(pds);
+        const posts = await manager.getPostsFromPds(limit);
+        spinner.succeed(`Retrieved ${posts.length} test posts`);
+
+        console.log(chalk.green("\nTest Posts:"));
+        posts.forEach((post: Partial<Record>, index) => {
+          console.log(
+            chalk.white(`\n${index + 1}. Created at: ${post.createdAt}`),
+          );
+          console.log(chalk.cyan(`   ${post.text}`));
+          console.log(chalk.gray(`   URI: ${post.uri}`));
+        });
+      } catch (error) {
+        console.error(chalk.red(`Error: ${(error as Error).message}`));
+      }
+    });
+};
+
+async function showTestMenu(pds: string) {
+  const { action } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "action",
+      message: "What would you like to do with your test account?",
+      choices: [
+        { name: "Generate test posts", value: "generate" },
+        { name: "List test posts", value: "list" },
+        { name: "Login to test account", value: "login" },
+        { name: "Exit", value: "exit" },
+      ],
+    },
+  ]);
+
+  console.log(chalk.cyan("\nUse the following command:"));
+  switch (action) {
+    case "generate":
+      console.log(chalk.white(`  bsky-backup test generate-posts`));
+      break;
+    case "list":
+      console.log(chalk.white(`  bsky-backup test list-posts`));
+      break;
+    case "login":
+      console.log(chalk.white(`  bsky-backup login --pds ${pds}`));
+      break;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,11 @@ const program = new Command().version("0.0.1");
 authCommands(program);
 pdsActions(program);
 program.parse(process.argv);
+
+process.on("uncaughtException", (error) => {
+  if (error instanceof Error && error.name === "ExitPromptError") {
+    console.log("👋 until next time!");
+  } else {
+    throw error;
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import { Command } from "commander";
-import { authCommands } from "./cli/commands"
+import { authCommands } from "./cli/commands";
+import { pdsActions } from "./cli/pds-actions";
 
-const program = new Command();
+const program = new Command().version("0.0.1");
 authCommands(program);
+pdsActions(program);
 program.parse(process.argv);

--- a/src/pds/account.ts
+++ b/src/pds/account.ts
@@ -1,0 +1,115 @@
+import { AtpAgent } from "@atproto/api";
+import { readConfig } from "../utils/config";
+
+export type AccountCreationPayload = {
+  email: string;
+  handle: string;
+  password: string;
+  inviteCode: string;
+};
+
+export type AccountAction = "account" | "post" | "posts" | "post-cid";
+
+export type PdsPostRecord = {
+  text: string;
+  createdAt: string;
+};
+
+const errorMessage = (action: AccountAction, error: Error) => {
+  switch (action) {
+    case "account":
+      return `create account ${error.message}`;
+    case "post":
+      return `create post ${error.message}`;
+    case "posts":
+      return `get posts ${error.message}`;
+    case "post-cid":
+      return `get post CID ${error.message}`;
+
+    default:
+      return error.message;
+  }
+};
+
+export class PdsAccountManager {
+  private agent: AtpAgent;
+  private pdsUrl: string;
+
+  constructor(pdsUrl?: string) {
+    const config = readConfig();
+    this.pdsUrl = pdsUrl || config.pdsUrl || "https://bsky.social";
+    this.agent = new AtpAgent({ service: this.pdsUrl });
+  }
+
+  async createAccountOnPds(payload: AccountCreationPayload) {
+    const { email, handle, password, inviteCode } = payload;
+
+    try {
+      const request = await this.agent.com.atproto.server.createAccount({
+        handle,
+        email,
+        password,
+        inviteCode
+      });
+      return request.data;
+    } catch (error) {
+      throw new Error(`Failed to ${errorMessage("account", error as Error)}`);
+    }
+  }
+
+  async createPostOnPds(text: string, replyTo?: string) {
+    try {
+      const record: any = {
+        text,
+        createdAt: new Date().toISOString(),
+      };
+
+      if (replyTo) {
+        record.reply = {
+          root: { uri: replyTo, cid: await this.getPostCid(replyTo) },
+          parent: { uri: replyTo, cid: await this.getPostCid(replyTo) },
+        };
+      }
+
+      const request = await this.agent.com.atproto.repo.createRecord({
+        repo: this.agent.session?.did || "",
+        collection: "app.bsky.feed.post",
+        record,
+      });
+      return request.data;
+    } catch (error) {
+      throw new Error(`Failed to ${errorMessage("post", error as Error)}`);
+    }
+  }
+
+  async getPostsFromPds(limit?: number) {
+    try {
+      const request = await this.agent.com.atproto.repo.listRecords({
+        limit: limit || 50,
+        repo: this.agent.session?.did || "",
+        collection: "app.bsky.feed.post",
+      });
+      return request.data.records;
+    } catch (error) {
+      throw new Error(`Failed to ${errorMessage("posts", error as Error)}`);
+    }
+  }
+
+  async getPostCid(uri: string): Promise<string> {
+    try {
+      const [repo, rkey] = uri.split("/").slice(-2);
+      const request = await this.agent.com.atproto.repo.getRecord({
+        repo,
+        rkey,
+        collection: "app.bsky.feed.post",
+      });
+
+      // now we can return the content identifier when it is founf
+      return request.data.cid as string;
+    } catch (error) {
+      throw new Error(
+        `Failed to get ${errorMessage("post-cid", error as Error)}`,
+      );
+    }
+  }
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,15 +1,12 @@
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { AtpSessionData } from "@atproto/api";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
 export interface Config {
   accounts: string[];
   pdsUrl?: string;
-  bluesky?: {
-    accessToken?: string;
-    refreshToken?: string;
-    did?: string;
-  };
+  bluesky?: Partial<AtpSessionData>;
   storacha?: {
     apiKey?: string;
   };
@@ -19,12 +16,30 @@ export const CONFIG_PATH = path.join(homedir(), ".bsky-backup-config.json");
 
 export const readConfig = (): Config => {
   if (!existsSync(CONFIG_PATH)) return { accounts: [] };
-  const data = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-  return { accounts: [], pdsUrl: "https://bsky.social", ...data };
+  try {
+    const data = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    return {
+      accounts: [],
+      pdsUrl: "https://atproto.storacha.network",
+      ...data,
+    };
+  } catch (error) {
+    console.error("Failed to read config:", error);
+    return { accounts: [] };
+  }
 };
 
 export const writeConfig = (config: Config) => {
-  const existing = readConfig();
-  const merged = { ...existing, ...config };
-  writeFileSync(CONFIG_PATH, JSON.stringify(merged, null, 2));
+  try {
+    mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+    const existing = readConfig();
+    const merged = {
+      ...existing,
+      ...config,
+      accounts: config.accounts ?? existing.accounts,
+    };
+    writeFileSync(CONFIG_PATH, JSON.stringify(merged, null, 2));
+  } catch (error) {
+    console.error("Failed to write config:", error);
+  }
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,7 +3,8 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 export interface Config {
-  accounts: string[],
+  accounts: string[];
+  pdsUrl?: string;
   bluesky?: {
     accessToken?: string;
     refreshToken?: string;
@@ -18,8 +19,8 @@ export const CONFIG_PATH = path.join(homedir(), ".bsky-backup-config.json");
 
 export const readConfig = (): Config => {
   if (!existsSync(CONFIG_PATH)) return { accounts: [] };
-  const data = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'));
-  return { accounts: [], ...data };
+  const data = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+  return { accounts: [], pdsUrl: "https://bsky.social", ...data };
 };
 
 export const writeConfig = (config: Config) => {


### PR DESCRIPTION
This PR ensures a compatible flow for the CLI by providing an option for people to bring their own Personal Data Server (PDS). If it isn't provided, we default to the bluesky server (https://bluesky.social/) which is retrieved from the config.

I'm not certain of the correctness of that URL (https://bluesky.social/), we can always update it later.

It also includes an account management module for overseeing actions on the provided PDS, such as the creation and retrieval of posts for testing. However, people can still decide to use the exposed methods &mdash; `createAccountOnPds`, `createPostOnPds`, getPostsFromPds` and `getPostCid` (if they want to reply a certain post) &mdash; in any way they deem fit, should they provide their PDSes