### PR TITLE
feat: decode CAR data for JSON retrieval flow 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+src
+public
+pnpm-lock.yaml
+package.json
+tsconfig.json
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.0.2 (2025-02-13)
+
+
+### Features
+
+* add auth ([efb4e0d](https://github.com/kaf-lamed-beyt/bsky-backups-cli/commit/efb4e0d2ea30d96b64fb2f7a7dec9579914a5b38))

--- a/README.md
+++ b/README.md
@@ -44,5 +44,7 @@ bb login --pds https://your-pds.com
 
 You'll need to use the command below to create posts on your PDS and follow the next prompts
 ```shell
-bb admin create-pots
+bb admin create-posts
 ```
+
+If you logged in with your Bluesky account, and used the command above, you're pretty much just creating a from the CLI

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # bsky-backups-cli
 
-A CLI tool that you can use to backup your Bluesky posts on Storacha
-
-![Bluesky backups CLI help interface](./public/bsky-backup.png)
+A CLI tool that you can use to backup your Bluesky posts/data on Storacha
 
 ## Usage
 
@@ -12,12 +10,39 @@ Install the CLI globally with the command below
 npm i -g bsky-backup
 ```
 
-To use the CLI you need to authenticate with your Bluesky handle (username) and a app password. It is different from your account password.
+To use the CLI you need to authenticate with your Bluesky handle (username) and  your password. If you try logging in and it isn't successful, you can use a app password.
 
-You can generate one by visting your [settings](https://bsky.app/settings/app-passwords)
+It is different from your account password. You can generate one by visting your [settings](https://bsky.app/settings/app-passwords)
 
-Login with the command below and you'll be prompted for your handle and the app password you've created.
+Login with the command below and you'll be prompted for your handle and password.
 
 ```shell
-bsky-backup login
+bb login
+```
+
+Once You're logged in, the next thing you may consider doing is logging into your Storacha account with the command below
+
+```shell
+bb storacha
+```
+
+Even if you forget to do this, do not worry, when you try to backup your data directly with this command `bb backup posts`, the CLI would automatically prompt you to login to Storacha.
+
+In the event that your backups to Storacha aren't successful, you can always access your data, either in `.car` or `.json` format and try to backup them up again. But, this time around, you'll use the command below and select the file(s) you'd love to backup.
+
+```shell
+bb backup upload
+```
+
+## PDS admin actions
+
+If you have your PDS, and you want to use the CLI, you'll first need to login with the auth command. It is quite similar with the initial one, where teh main difference is the extra `--pds` flag.
+
+```shell
+bb login --pds https://your-pds.com
+```
+
+You'll need to use the command below to create posts on your PDS and follow the next prompts
+```shell
+bb admin create-pots
 ```

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@atproto/api": "^0.13.35",
     "@atproto/oauth-client-node": "^0.2.10",
+    "@ipld/car": "^5.4.0",
+    "@ipld/dag-cbor": "^9.2.2",
     "@web3-storage/w3up-client": "^17.2.0",
     "axios": "^1.7.9",
     "chalk": "^5.4.1",
@@ -27,6 +29,7 @@
     "esbuild": "^0.25.0",
     "inquirer": "^12.4.1",
     "keytar": "^7.9.0",
+    "multiformats": "^13.3.2",
     "ora": "^8.2.0",
     "standard-version": "^9.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky-backups-cli",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky-backups-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@atproto/oauth-client-node':
         specifier: ^0.2.10
         version: 0.2.10
+      '@ipld/car':
+        specifier: ^5.4.0
+        version: 5.4.0
+      '@ipld/dag-cbor':
+        specifier: ^9.2.2
+        version: 9.2.2
       '@web3-storage/w3up-client':
         specifier: ^17.2.0
         version: 17.2.0(encoding@0.1.13)
@@ -35,6 +41,9 @@ importers:
       keytar:
         specifier: ^7.9.0
         version: 7.9.0
+      multiformats:
+        specifier: ^13.3.2
+        version: 13.3.2
       ora:
         specifier: ^8.2.0
         version: 8.2.0

--- a/src/auth/bsky.ts
+++ b/src/auth/bsky.ts
@@ -1,4 +1,4 @@
-import { Config, readConfig, writeConfig } from "../utils/config";
+import { Config, DEFAULT_SERVICE_URL, readConfig, writeConfig } from "../utils/config";
 import inquirer from "inquirer";
 import chalk from "chalk";
 import ora from "ora";
@@ -16,7 +16,7 @@ export class BlueskyAuth {
     let validServiceUrl = serviceUrl;
     if (!validServiceUrl || validServiceUrl === "undefined")
       validServiceUrl =
-        this.config.pdsUrl || "https://atproto.storacha.network";
+        this.config.pdsUrl || "https://bsky.social";
 
     this.serviceUrl = validServiceUrl;
     this.session = new Session(this.serviceUrl);
@@ -93,7 +93,11 @@ export class BlueskyAuth {
       {
         type: "input",
         name: "identifier",
-        message: `Enter your bluesky handle (e.g. user.${new URL(pdsUrl).hostname}):`,
+        message: `Enter your ${pdsUrl !== new URL(DEFAULT_SERVICE_URL)
+          ? "" :
+          "Bluesky"}handle (e.g. user.${pdsUrl.hostname !== new URL(DEFAULT_SERVICE_URL).hostname ?
+          pdsUrl.hostname :
+            new URL(DEFAULT_SERVICE_URL).hostname}):`,
         validate: (input: string) => {
           const host = new URL(pdsUrl).hostname;
           return input.endsWith(host) || input.includes(".")
@@ -104,8 +108,8 @@ export class BlueskyAuth {
       {
         type: "password",
         name: "password",
-        message: "Enter your Bluesky app password:",
         mask: true,
+        message: `Enter your ${pdsUrl !== new URL(DEFAULT_SERVICE_URL) ? "": "Bluesky app"}password:`,
       },
     ]);
 

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -12,7 +12,7 @@ export class Session {
   constructor(pdsUrl?: string) {
     this.config = readConfig();
     const serviceUrl =
-      pdsUrl || this.config.pdsUrl || "https://atproto.storacha.network";
+      pdsUrl || this.config.pdsUrl || "https://bsky.social";
 
     try {
       const session = new CredentialSession(new URL(serviceUrl));
@@ -54,7 +54,11 @@ export class Session {
       ...this.config,
       accounts: [
         ...this.config.accounts,
-        { did: session.did, handle: session.handle },
+        {
+          did: session.did,
+          handle: session.handle,
+          serviceUrl: this.agent.serviceUrl.toString()
+        },
       ],
       pdsUrl: this.agent.serviceUrl.toString(),
       bluesky: { ...session },

--- a/src/auth/storacha.ts
+++ b/src/auth/storacha.ts
@@ -168,16 +168,6 @@ export class StorachaAuth {
     const selectedSpace = spaces.find((space) => space.did() === spaceOption);
     if (selectedSpace) {
       await client.setCurrentSpace(selectedSpace.did());
-
-      // try {
-      //   const spinner = ora("Verifying storage provider...").start();
-      //   await client.capability.upload.list();
-      //   spinner.succeed();
-      // } catch (error) {
-      //   console.log(chalk.yellow("This space needs storage provisioning"));
-      //   await this.createStorachaSpace(client);
-      // }
-
       console.log(
         chalk.green(
           `Selected space: ${selectedSpace.name || selectedSpace.did()}`,

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -2,7 +2,7 @@
 import chalk from "chalk";
 import { BlueskyAuth } from "../auth/bsky";
 import { Command } from "commander";
-import { readConfig } from "../utils/config";
+import { readConfig, writeConfig } from "../utils/config";
 
 export const authCommands = (program: Command) => {
   program
@@ -28,7 +28,16 @@ export const authCommands = (program: Command) => {
     .description("Remove stored credentials")
     .action(async () => {
       const auth = new BlueskyAuth();
+      const config = readConfig()
+      const accounts = config.accounts
       auth.logout();
+
+      if (accounts?.length > 0) {
+       writeConfig({
+         ...config,
+         pdsUrl: accounts[0]?.serviceUrl
+       })
+      }
     });
 
   program.addHelpText(

--- a/src/cli/pds-actions.ts
+++ b/src/cli/pds-actions.ts
@@ -4,7 +4,6 @@ import ora from "ora";
 import inquirer from "inquirer";
 import { PdsAccountManager } from "../pds/account";
 import { BlueskyAuth } from "../auth/bsky";
-import { Record } from "@atproto/api/dist/client/types/com/atproto/repo/listRecords";
 import { readConfig } from "../utils/config";
 
 export const pdsActions = (program: Command) => {

--- a/src/cli/pds-actions.ts
+++ b/src/cli/pds-actions.ts
@@ -5,6 +5,7 @@ import inquirer from "inquirer";
 import { PdsAccountManager } from "../pds/account";
 import { BlueskyAuth } from "../auth/bsky";
 import { Record } from "@atproto/api/dist/client/types/com/atproto/repo/listRecords";
+import { readConfig } from "../utils/config";
 
 export const pdsActions = (program: Command) => {
   const bluesky = new BlueskyAuth();
@@ -115,7 +116,7 @@ export const pdsActions = (program: Command) => {
             message: "What type of test posts would you like to generate?",
             choices: [
               { name: "Single test post", value: "single" },
-              { name: "Test reply to another post", value: "reply" },
+              { name: "Reply to another post", value: "reply" },
             ],
           },
         ]);
@@ -173,32 +174,16 @@ export const pdsActions = (program: Command) => {
     .action(async () => {
       try {
         const pds = await bluesky.getPdsUrl();
-
-        const { limit } = await inquirer.prompt([
-          {
-            type: "number",
-            name: "limit",
-            message: "How many posts to retrieve?",
-            default: 10,
-            required: false,
-          },
-        ]);
+        const config = readConfig();
+        const did: string = config.bluesky?.did || ""
 
         const spinner = ora("Fetching test posts...").start();
         const manager = new PdsAccountManager(pds);
-        const posts = await manager.getPostsFromPds(limit);
-        spinner.succeed(`Retrieved ${posts.length} test posts`);
+        const posts = await manager.getPostsFromPds(did);
+        spinner.succeed(`Data retrieved successfully!`);
 
-        console.log(chalk.green("\nTest Posts:"));
-        posts.forEach((post: Record, index) => {
-          console.log(
-            // @ts-ignore
-            chalk.white(`\n${index + 1}. Created at: ${post.value.createdAt}`),
-          );
-          // @ts-ignore
-          console.log(chalk.cyan(`   ${post.value.text}`));
-          console.log(chalk.gray(`   URI: ${post.uri}`));
-        });
+        console.log(chalk.green("Available Data:"));
+        console.log(posts)
       } catch (error) {
         console.error(chalk.red(`Error: ${(error as Error).message}`));
       }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,9 +3,12 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
+export const DEFAULT_SERVICE_URL = "https://bsky.social"
+
 export type Account = {
   did: string;
   handle: string
+  serviceUrl?: string;
 }
 
 export interface Config {
@@ -26,7 +29,7 @@ export const readConfig = (): Config => {
     const data = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     return {
       accounts: [],
-      pdsUrl: "https://atproto.storacha.network",
+      pdsUrl: DEFAULT_SERVICE_URL,
       ...data,
     };
   } catch (error) {

--- a/src/utils/decode.ts
+++ b/src/utils/decode.ts
@@ -1,0 +1,30 @@
+import * as car from '@ipld/car'
+import * as dagCbor from "@ipld/dag-cbor"
+import * as Block from "multiformats/block"
+import { sha256 } from 'multiformats/hashes/sha2'
+
+export async function decodeCarToJson(data: Uint8Array) {
+  const decoder = await car.CarReader.fromBytes(data)
+  const blocks = []
+
+  for await (const block of decoder.blocks()) {
+    try {
+      const decoded = dagCbor.decode(block.bytes)
+      blocks.push({
+        cid: block.cid.toString(),
+        data: decoded
+      })
+    } catch (error) {
+      // just incase we have blocks that are not CBOR-encoded
+      blocks.push({
+        cid: block.cid.toString(),
+        data: {
+          bytes: [...block.bytes]
+        }
+      })
+      console.error(`${(error as Error).message}`)
+    }
+  }
+
+  return blocks
+}


### PR DESCRIPTION
This PR introduces a refactor to the option that allows people to save their backups as JSON. The initial approach used the `litsRecord` method which is limited because we can't obtain the entire snapshot of the user's data due to pagination

Although, this method already returns JSON data for us, but it isn't exactly absolute. To solve this, we rely on the some packages from the IPLD ecosystem in support of DAG-CBOR ops which allows us to convert the stream of data from the `sync.getRepo` method.

This PR also included an update to the README that'll guide people on how to use the CLI.

More updates coming soon.