### PR TITLE
refactor: updated the storacha/bsky auth-to-upload flow 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.0.2 (2025-02-13)
+
+
+### Features
+
+* add auth ([efb4e0d](https://github.com/kaf-lamed-beyt/bsky-backups-cli/commit/efb4e0d2ea30d96b64fb2f7a7dec9579914a5b38))

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# bsky-backups-cli
+# bsky-backup-cli
 
-A CLI tool that you can use to backup your Bluesky posts/data on Storacha
+HOT HOT HOT backups for your Bluesky data on Storacha! 🐔
 
 ## Usage
 
 Install the CLI globally with the command below
 
 ```shell
-npm i -g bsky-backup
+npm i -g bsky-backup-cli
 ```
 
-To use the CLI you need to authenticate with your Bluesky handle (username) and  your password. If you try logging in and it isn't successful, you can use a app password.
+To use the CLI you need to authenticate with your Bluesky handle (username) and your password. If you try logging in and it isn't successful, you can use an app password.
 
 It is different from your account password. You can generate one by visting your [settings](https://bsky.app/settings/app-passwords)
 
@@ -28,7 +28,7 @@ bb storacha
 
 Even if you forget to do this, do not worry, when you try to backup your data directly with this command `bb backup posts`, the CLI would automatically prompt you to login to Storacha.
 
-In the event that your backups to Storacha aren't successful, you can always access your data, either in `.car` or `.json` format and try to backup them up again. But, this time around, you'll use the command below and select the file(s) you'd love to backup.
+In the event that your backups to Storacha aren't successful, you can always access your data, either in `.car` or `.json` format and try to back them up again. But, this time around, you'll use the command below and select the file(s) you'd love to backup.
 
 ```shell
 bb backup upload
@@ -36,7 +36,7 @@ bb backup upload
 
 ## PDS admin actions
 
-If you have your PDS, and you want to use the CLI, you'll first need to login with the auth command. It is quite similar with the initial one, where teh main difference is the extra `--pds` flag.
+If you have your PDS, and you want to use the CLI, you'll first need to login with the auth command. It is quite similar with the initial one, where the main difference is the extra `--pds` flag.
 
 ```shell
 bb login --pds https://your-pds.com
@@ -47,4 +47,6 @@ You'll need to use the command below to create posts on your PDS and follow the 
 bb admin create-posts
 ```
 
-If you logged in with your Bluesky account, and used the command above, you're pretty much just creating a from the CLI
+If you logged in with your Bluesky account, and used the command above, any post you make will reflect on your Bluesky account. Quite cool! Isn't it?
+
+You can explore the available commands with `bb --help`

--- a/package.json
+++ b/package.json
@@ -1,17 +1,48 @@
 {
   "name": "bsky-backup-cli",
   "version": "0.0.1",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "build": "esbuild ./src/index.ts --bundle --platform=node --outfile=dist/index.js --external:keytar"
+  "description": "HOT HOT HOT backups for your Bluesky data on Storacha! 🐔",
+  "main": "dist/index.js",
+  "engines": {
+    "node": ">=18.0.0"
   },
   "bin": {
     "bb": "./dist/index.js"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "scripts": {
+    "build": "esbuild ./src/index.ts --bundle --platform=node --target=node18 --outfile=dist/index.js --external:keytar",
+    "prepare": "npm run build",
+    "prepack": "npm run build",
+    "dev": "ts-node src/index.ts",
+    "start": "node dist/index.js",
+    "version": "standard-version",
+    "release": "npm run version && npm publish"
+  },
+  "keywords": [
+    "bluesky",
+    "backups",
+    "storacha",
+    "web3",
+    "storage",
+    "upload",
+    "store",
+    "IPLD",
+    "UCAN",
+    "IPFS"
+  ],
+  "files": [
+    "dist"
+  ],
+  "author": "Storacha",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/storacha/bsky-backup-cli.git"
+  },
+  "homepage": "https://github.com/storacha/bsky-backup-cli#readme",
+  "bugs": {
+    "url": "https://github.com/storacha/bsky-backup-cli/issues"
+  },
   "devDependencies": {
     "@types/node": "^22.13.1",
     "ts-node": "^10.9.2",
@@ -32,5 +63,8 @@
     "multiformats": "^13.3.2",
     "ora": "^8.2.0",
     "standard-version": "^9.5.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky-backups-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bsky-backups-cli",
+  "name": "bsky-backup-cli",
   "version": "0.0.1",
   "description": "",
   "main": "index.js",

--- a/src/auth/bsky.ts
+++ b/src/auth/bsky.ts
@@ -117,23 +117,19 @@ export class BlueskyAuth {
     try {
       const session = await agent.login({ identifier, password });
       await this.session.saveSession(session.data);
-      spinner.succeed(`Successfully logged in as ${session.data.handle}`);
+      spinner.succeed(`Successfully logged in as ${chalk.blue.bold(session.data.handle)}`);
       return true;
     } catch (error) {
       spinner.fail(`Authentication failed: ${(error as Error).message}`);
-      console.log(chalk.yellow("  Troubleshooting:"));
+      console.log(chalk.yellow(" Troubleshooting:"));
       console.log(
-        chalk.yellow("  1.") +
-          " Ensure you're using an app password, not your main account password",
-      );
-      console.log(
-        chalk.yellow("  2.") +
+        chalk.yellow(" 1.") +
           " Verify your handle format (e.g., " +
           chalk.bgBlue(`user.${new URL(pdsUrl).hostname}`) +
           ")",
       );
       console.log(
-        chalk.yellow("  3.") +
+        chalk.yellow(" 2.") +
           " Check account status at: " +
           chalk.blue("https://bsky.app/settings"),
       );
@@ -154,7 +150,7 @@ export class BlueskyAuth {
         name: "did",
         message: "Select account to logout:",
         choices: accounts.map((account) => ({
-          name: `${account.handle} (${account.did})`,
+          name: `${chalk.blue(account.handle)} (${chalk.blue(account.did)})`,
           value: account.did
         })),
       },

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -37,7 +37,7 @@ export class Session {
           active: Boolean(this.config.bluesky.active),
         })
         .catch((error) => {
-          console.log(`${chalk.yellow(`\nError resuming session:`, error)}`);
+          // console.log(`${chalk.yellow(`Error resuming session:`, error)}`);
         });
     }
   }

--- a/src/utils/decode.ts
+++ b/src/utils/decode.ts
@@ -1,7 +1,5 @@
 import * as car from '@ipld/car'
 import * as dagCbor from "@ipld/dag-cbor"
-import * as Block from "multiformats/block"
-import { sha256 } from 'multiformats/hashes/sha2'
 
 export async function decodeCarToJson(data: Uint8Array) {
   const decoder = await car.CarReader.fromBytes(data)


### PR DESCRIPTION
The major reason behind the issue we thought was fixed in https://github.com/storacha/bluesky-backup-cli/pull/6 isn't really accurate. Sometimes, people do not authenticate with Storacha initially and they proceed to use the `bb backup posts` command which walks them through the process of selecting the data format (CAR|JSON), to authenticating with Storacha, choosing a space if they haven't and finally backing up their data.

Since this happens or at least, I experienced it a lot of times, we're always stuck on the 'Establishing connection..." step, because there's no email to auth with. The ideal thing to do is to prompt people to log in, if we can't find any auth session/state in the config. If there's an auth session, this flow works as it should.

This commit also includes typo fixes in the README and general updates to the 'how-to' guide